### PR TITLE
Use build directory for publishing

### DIFF
--- a/dagger/dagger.go
+++ b/dagger/dagger.go
@@ -58,7 +58,7 @@ func main() {
     os.Exit(1)
   }
 
-  cn,err := client.Container().Build(src).Publish(ctx, "nicholasjackson/dagger-example:latest")
+  cn,err := client.Container().Build(build).Publish(ctx, "nicholasjackson/dagger-example:latest")
   if err != nil {
     fmt.Printf("Error creating and pushing container: %s", err)
     os.Exit(1)


### PR DESCRIPTION
When using `src` directory in
```
cn,err := client.Container().Build(src).Publish(ctx, "nicholasjackson/dagger-example:latest")
```
the container will have initial state of the directory (build context). That means artifact used in publish will be from previous run. As for first run without `build` directory in host workdir, it will fail.

To use actual artifact from run use 
```
build,err := golang.Directory(path).ID(ctx)
```
directory ID provided here which points to directory that the
```
go build -o build/
```
command outputs the artifact to.
